### PR TITLE
feat: add acess token blacklist & swagger setting

### DIFF
--- a/src/main/java/study/issue_mate/config/SwaggerConfig.java
+++ b/src/main/java/study/issue_mate/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package study.issue_mate.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,11 +12,29 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
 
     @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI().info(info);
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+            .components(new Components()
+                .addSecuritySchemes("bearerAuth", createSecurityScheme()))
+            .info(info())
+            .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
-    Info info = new Info()
+
+    private Info info() {
+        return new Info()
             .title("ISSUE MATE")
             .version("1.0")
             .description("이슈 관리 API");
+    }
+
+    /**
+     * JWT 인증을 위한 SecurityScheme 설정
+     */
+    private SecurityScheme createSecurityScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP) // HTTP 인증 방식
+            .scheme("bearer") // Bearer 토큰 방식
+            .bearerFormat("JWT") // JWT 토큰 형식
+            .description("JWT Bearer 토큰을 입력하세요");
+    }
 }

--- a/src/main/java/study/issue_mate/exception/JWTErrorType.java
+++ b/src/main/java/study/issue_mate/exception/JWTErrorType.java
@@ -15,7 +15,9 @@ public enum JWTErrorType implements ErrorCode {
 
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "로그인이 만료되었습니다. 다시 로그인 해주세요.");
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "로그인이 만료되었습니다. 다시 로그인 해주세요."),
+
+    BLACKLISTED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "블랙리스트에 등록된 토큰입니다.");
 
     private final HttpStatus status;
     private final String desc;

--- a/src/main/java/study/issue_mate/jwt/CustomLogoutFilter.java
+++ b/src/main/java/study/issue_mate/jwt/CustomLogoutFilter.java
@@ -24,6 +24,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
     private final JWTProvider jwtProvider;
     private final RedisUtil redisUtil;
+    private final JwtBlacklistService jwtBlacklistService;
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
@@ -45,6 +46,15 @@ public class CustomLogoutFilter extends GenericFilterBean {
             return;
         }
 
+        // Access token 블랙리스트 처리
+        String accessToken = request.getHeader("Authorization");
+        if (accessToken != null && accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+
+            // access token의 남은 유효시간을 가져오는 메소드
+            long expirationMillis = jwtProvider.getRemainingMillis(accessToken);
+            jwtBlacklistService.addTokenBlacklist(accessToken, expirationMillis);
+        }
         String refresh = null;
         Cookie[] cookies = request.getCookies();
         if(cookies != null) {

--- a/src/main/java/study/issue_mate/jwt/JWTFilter.java
+++ b/src/main/java/study/issue_mate/jwt/JWTFilter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTProvider jwtProvider;
+    private final JwtBlacklistService jwtBlacklistService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -33,6 +34,12 @@ public class JWTFilter extends OncePerRequestFilter {
             return;
         }
         String accessToken = authorization.split(" ")[1];
+
+        // check if the token is blacklisted
+        if (jwtBlacklistService.isTokenBlacklisted(accessToken)) {
+            JwtExceptionResponseUtil.unAuthentication(response, JWTErrorType.BLACKLISTED_ACCESS_TOKEN);
+            return;
+        }
 
         try {
             jwtProvider.isTokenExpired(accessToken);

--- a/src/main/java/study/issue_mate/jwt/JWTProvider.java
+++ b/src/main/java/study/issue_mate/jwt/JWTProvider.java
@@ -62,4 +62,14 @@ public class JWTProvider {
 
         return false;
     }
+
+    /**
+     * access token의 남은 유효시간을 반환하는 메소드
+     * 로그아웃 시 access token의 남은 유효시간을 확인하기 위해서는 토큰의 만료 시간(expiration)을 가져와서 현재 시간과의 차이를 계산하는 메소드 필요
+     */
+    public long getRemainingMillis(String token) {
+        Date expiration = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+            .getPayload().getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
 }

--- a/src/main/java/study/issue_mate/jwt/JwtBlacklistService.java
+++ b/src/main/java/study/issue_mate/jwt/JwtBlacklistService.java
@@ -1,0 +1,26 @@
+package study.issue_mate.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import study.issue_mate.util.RedisUtil;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class JwtBlacklistService {
+
+   private final RedisUtil redisUtil;
+    /**
+     *
+     * @param token access token 문자열
+     * @param expirationMillis 토큰의 남은 유효시간 (밀리초)
+     */
+    public void addTokenBlacklist(String token, long expirationMillis) {
+        redisUtil.setValues(token, "blacklisted", expirationMillis);
+    }
+
+    public boolean isTokenBlacklisted(String token) {
+        return redisUtil.checkExistsValue(token);
+    }
+}


### PR DESCRIPTION
**1. Access Token 블랙리스트 및 Redis 저장**
- **JwtBlacklistService**
    - **추가된 메소드:**
        - addTokenBlacklist(String token, long expirationMillis): 전달받은 access token을 “blacklisted” 값과 함께 Redis에 저장(만료 시간: 밀리초 단위).
        - isTokenBlacklisted(String token): Redis에 토큰이 저장되어 있는지 확인하여 블랙리스트 여부를 판단.

**2. JWTFilter 수정**

- **블랙리스트 체크 추가:**
    - access token이 블랙리스트에 등록되어 있는 경우, JwtExceptionResponseUtil.unAuthentication()을 호출하여 인증 실패 응답(예: 401)을 반환.

**3. CustomLogoutFilter 수정**

- **로그아웃 시 access token 블랙리스트 처리:**
    - 로그아웃 요청 시, HTTP 헤더의 Authorization에서 access token을 추출하고, 남은 유효시간을 jwtProvider.getRemainingMillis()를 통해 계산하여 블랙리스트에 등록.

**4. Swagger 설정 (SwaggerConfig)**

- **JWT 인증 설정:**
    - Swagger를 통해 API 문서를 사용할 때 JWT Bearer 토큰 인증을 적용하도록 SecurityScheme을 설정.
    - OpenAPI 객체에 해당 SecurityScheme을 등록하여, Swagger UI에서 인증 헤더를 입력할 수 있게 구성.

**5. SecurityConfig 수정**

- **Swagger 접근 허용:**
    - /swagger-ui/**, /v3/api-docs/** 등의 경로에 대해서는 인증 없이 접근할 수 있도록 permitAll() 설정을 추가.
    - 그 외의 모든 요청은 인증이 필요하도록 구성.